### PR TITLE
Switch to local Ollama client

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,21 @@ pip install -r requirements.txt
 
 #### Configure Environment Variables
 
-We use OpenAI for the LLM (you can modify/replace it in `src/util/invoke_ai.py`). Make sure to set your OpenAI API key. For example:
+This project now uses [Ollama](https://ollama.ai/) to run the LLM locally.  Set
+the server URL and model name using the following environment variables (defaults
+are shown):
 
 ```sh
-export OPENAI_API_KEY='your_openai_api_key'
+export OLLAMA_URL="http://localhost:11434"
+export OLLAMA_MODEL="phi3"
 ```
 
-You will also need a Cohere key for the re-ranking feature used in `src/impl/retriever.py`. You can create an account and create an API key at https://cohere.com/
+If you still wish to use the OpenAI API you can modify `src/util/invoke_ai.py`
+and set `OPENAI_API_KEY`.  You will also need a Cohere key for the re‑ranking
+feature used in `src/impl/retriever.py`:
 
 ```sh
-set -x CO_API_KEY "xxx"
+export CO_API_KEY="xxx"
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ openai>=1.0.0  # For AI service integration
 lancedb==0.22.0
 docling==2.31.0
 cohere==5.15.0
+requests>=2.0.0

--- a/src/impl/evaluator.py
+++ b/src/impl/evaluator.py
@@ -1,5 +1,5 @@
 from interface.base_evaluator import BaseEvaluator, EvaluationResult
-from util.invoke_ai import invoke_ai
+from util.invoke_ai import invoke_ai2
 from util.extract_xml import extract_xml_tag
 
 SYSTEM_PROMPT = """
@@ -27,8 +27,11 @@ class Evaluator(BaseEvaluator):
         <expected_answer>\n{expected_answer}\n</expected_answer>
         """
 
-        response_content = invoke_ai(
-            system_message=SYSTEM_PROMPT, user_message=user_prompt
+        response_content = invoke_ai2(
+            None,
+            None,
+            system_message=SYSTEM_PROMPT,
+            user_message=user_prompt,
         )
 
         reasoning = extract_xml_tag(response_content, "reasoning")

--- a/src/impl/response_generator.py
+++ b/src/impl/response_generator.py
@@ -1,6 +1,6 @@
 from typing import List
 from interface.base_response_generator import BaseResponseGenerator
-from util.invoke_ai import invoke_ai
+from util.invoke_ai import invoke_ai2
 
 
 SYSTEM_PROMPT = """
@@ -19,4 +19,4 @@ class ResponseGenerator(BaseResponseGenerator):
             f"<question>\n{query}\n</question>"
         )
 
-        return invoke_ai(system_message=SYSTEM_PROMPT, user_message=user_message)
+        return invoke_ai2(None, None, system_message=SYSTEM_PROMPT, user_message=user_message)

--- a/src/util/invoke_ai.py
+++ b/src/util/invoke_ai.py
@@ -1,4 +1,5 @@
 from openai import OpenAI
+import os
 
 
 def invoke_ai(system_message: str, user_message: str) -> str:
@@ -20,14 +21,19 @@ def invoke_ai(system_message: str, user_message: str) -> str:
 from ollama_remote_client import OllamaRemoteClient
 
 def invoke_ai2(
-    ollama_url: str,
-    ollama_model: str,
+    ollama_url: str | None,
+    ollama_model: str | None,
     system_message: str,
     user_message: str,
 ) -> str:
     """
     Invia due messaggi (system e user) al modello Ollama e restituisce la risposta.
     """
+
+    if ollama_url is None:
+        ollama_url = os.getenv("OLLAMA_URL", "http://localhost:11434")
+    if ollama_model is None:
+        ollama_model = os.getenv("OLLAMA_MODEL", "phi3")
 
     llm = OllamaRemoteClient(ollama_url, ollama_model)
 


### PR DESCRIPTION
## Summary
- add environment-variable support to `invoke_ai2`
- use `invoke_ai2` in ResponseGenerator and Evaluator
- document Ollama setup in the README
- include requests dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68405b961ab883339104293ff089e50a